### PR TITLE
Code refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Byte-compiled / optimized / DLL files
+notebooks/
+plots/
 __pycache__/
+*.code-workspace
+*.vscode
 *.py[cod]
 *$py.class
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ### highlight_text
 
 This package provides two functions that allow you to plot text with <highlighted substrings> in matplotlib:
- - htext for plotting onto an axes in data coordinates.  
- - fig_htext for plotting onto the figure in figure coordinates.  
+ - ax_text for plotting onto an axes in data coordinates.  
+ - fig_text for plotting onto the figure in figure coordinates.  
 
 They take a string with substring delimiters = ['<', '>'] to be highlighted according to highlight colors:
 'The weather is (sunny) today. Yesterday it (rained).', color = 'k', highlight_colors = ['C1', 'grey']
@@ -13,19 +13,20 @@ prints the text with 'sunny' as orange and 'rained' as grey.
 A minimal example would be (Replace () with delimiters <> - markdown won't show them):  
 
     import matplotlib.pyplot as plt
-    from highlight_text.htext import htext, fig_htext  
+    from highlight_text import ax_text, fig_text
+    # or
+    import highlight_text # then use highlight_text.ax_text or highlight_text.fig_text
+<pre><code>fig, ax = plt.subplots()  
+ax_text(x = 0, y = 0.5,
+        s = 'The weather is (sunny) today. Yesterday it (rained).'
+        color = 'k', highlight_colors = ['C1', 'grey'])</code></pre>
+
+or for the fig_text:
 
 <pre><code>fig, ax = plt.subplots()  
-htext(s = 'The weather is (sunny) today. Yesterday it (rained).',
-          x = 0, y = 0.5,
-          color = 'k', highlight_colors = ['C1', 'grey'])</code></pre>
-
-or for the fig_htext:
-
-<pre><code>fig, ax = plt.subplots()  
-fig_htext(s = 'The weather is (sunny) today. Yesterday it (rained).',
-              x = 0, y = 0.5,
-              color = 'k', highlight_colors = ['C1', 'grey'])</code></pre>
+fig_text(x = 0, y = 0.5,
+         s = 'The weather is (sunny) today. Yesterday it (rained).',
+         color = 'k', highlight_colors = ['C1', 'grey'])</code></pre>
 
 You can further highlight by using  
 highlight_styles ie. ['normal', 'italic', 'oblique']  
@@ -33,7 +34,7 @@ and highlight_weights ie. ['regular', 'bold'].
 
 This does work with linebreaks \n, fstrings and ha in ['left', 'right', 'center'] as well as va in ['botton', 'top', 'center'].
 
-<b>Make sure to set data limits and if used call plt.tight_layout() before using the htext function. Otherwise the data transformation will not show properly.</b>
+<b>Make sure to set data limits and if used call plt.tight_layout() before using the ax_text function. Otherwise the data transformation will not show properly.</b>
 
 
 ### Installation
@@ -46,16 +47,16 @@ This does work with linebreaks \n, fstrings and ha in ['left', 'right', 'center'
 
 Parameters:  
 ##########
-
-s: text including highlighted substrings  
+  
 x: x position with left alignment  
 y: y position  
+s: text including highlighted substrings
 color: textcolor of unhighlighted text  
 highlight_colors: list of highlight colors  
 highlight_weights = ['regular']: the fontweight used for highlighted text  
 highlight_styles = ['normal']: the fontstyle used for highlighted text  
-string_weight = 'regular': the fontweight used for normal text  
-string_style = 'normal': the fontstyle used for normal text  
+fontweight = 'regular': the fontweight used for normal text  
+fontstyle = 'normal': the fontstyle used for normal text  
 delim = ['<', '>']: delimiters to enclose the highlight substrings  
 va = 'bottom', textalignment has to be in ['bottom', 'top', 'center']  
 ha = 'left', textalignment has to be in ['left', 'right', 'center']  

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ ha = 'left', textalignment has to be in ['left', 'right', 'center']
 hpadding = 0: extra padding between highlight and normal text  
 linespacing = 0.25: linespacing in factor of font height between rows  
 **kwargs: figure.text | plt.text kwargs  
-[ax: axes to draw the text onto (in case of htext)]  
-[fig: figure(in case of fig_htext)]  
+[ax: axes to draw the text onto (in case of ax_text)]  
+[fig: figure(in case of fig_text)]  
 
 Returns:  
 ##########

--- a/highlight_text/__init__.py
+++ b/highlight_text/__init__.py
@@ -1,0 +1,1 @@
+from highlight_text.htext import ax_text, fig_text

--- a/highlight_text/htext.py
+++ b/highlight_text/htext.py
@@ -1,22 +1,26 @@
 import numpy as np
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 
-def htext(s, x, y,
-          color='k',
-          highlight_colors=['C1'],
-          highlight_weights=['regular'],
-          highlight_styles=['normal'],
-          string_weight='regular',
-          string_style='normal',
-          ax=None,
-          delim=['<', '>'],
-          va='bottom',
-          ha='left',
-          hpadding=0,
-          linespacing=0.25,
-          **kwargs):
+def ax_text(x, y, s,
+            color=None,
+            highlight_colors=['C1'],
+            highlight_weights=['regular'],
+            highlight_styles=['normal'],
+            fontweight='regular',
+            fontstyle='normal',
+            ax=None,
+            delim=['<', '>'],
+            va='bottom',
+            ha='left',
+            hpadding=0,
+            linespacing=0.25,
+            **kwargs):
     '''
+    NOTE: do not use plt.tight_layout() after using this
+    method as it adjusts the margins and spacing. Better to
+    use constrained_layout=True as an arg when you create figure.
     Takes a string with substrings delimiters = ['<', '>']
     to be highlighted according to highlight colors:
     'The weather is <sunny> today. Yesterday it <rained>.',
@@ -36,8 +40,8 @@ def htext(s, x, y,
     highlight_colors: list of highlight colors
     highlight_weights = ['regular']: the fontweight used for highlighted text
     highlight_styles = ['normal']: the fontstyle used for highlighted text
-    string_weight = 'regular': the fontweight used for normal text
-    string_style = 'normal': the fontstyle used for normal text
+    fontweight = 'regular': the fontweight used for normal text
+    fontstyle = 'normal': the fontstyle used for normal text
     ax: axes to draw the text onto
     delim = ['<', '>']: delimiters to enclose the highlight substrings
     va = 'bottom', textalignment has to be in ['bottom', 'top', 'center']
@@ -51,6 +55,10 @@ def htext(s, x, y,
 
     a list of texts
     '''
+
+    if color is None:
+        color = mpl.rcParams['text.color']
+
     def is_empty_string(string):
         return string.strip() == ''
 
@@ -72,7 +80,7 @@ def htext(s, x, y,
     if len(highlight_colors) == 1:
         highlight_colors = np.repeat(highlight_colors, n_highlights)
     else:
-        assert n_highlights == len(highlight_colors), f'You should specify either one highlight color or the same number as text highlights.\nYou input {n_highlights} highlights and {len(highlight_colors)} colors.'    
+        assert n_highlights == len(highlight_colors), f'You should specify either one highlight color or the same number as text highlights.\nYou input {n_highlights} highlights and {len(highlight_colors)} colors.'
 
     if len(highlight_weights) == 1:
         highlight_weights = np.repeat(highlight_weights, n_highlights)
@@ -114,12 +122,12 @@ def htext(s, x, y,
                 if i % 2 == 1:
                     colors.append(highlight_colors[highlight_count])
                     weights.append(highlight_weights[highlight_count])
-                    styles.append(highlight_styles[highlight_count])                
+                    styles.append(highlight_styles[highlight_count])
                     highlight_count += 1
                 else:
                     colors.append(color)
-                    weights.append(string_weight)
-                    styles.append(string_style)
+                    weights.append(fontweight)
+                    styles.append(fontstyle)
 
             texts = []
 
@@ -141,8 +149,8 @@ def htext(s, x, y,
 
             textline_hight = tcboxes[0, -1] - tcboxes[0, 1]
             textline_widths.append((tcboxes[:, 2] - tcboxes[:, 0]).sum())
-            textbox_hight = (tcboxes[0, -1] - tcboxes[0, 1]) * (len(text_rows)
-                            + (len(text_rows) - 1) * linespacing)
+            textbox_hight = ((tcboxes[0, -1] - tcboxes[0, 1]) * (len(text_rows)
+                             + (len(text_rows) - 1) * linespacing))
 
             textline_xs.append(np.hstack([tcboxes[0, 0],
                                           tcboxes[0, 0]
@@ -179,20 +187,20 @@ def htext(s, x, y,
     return row_texts
 
 
-def fig_htext(s, x, y,
-              color='k',    
-              highlight_colors=['C1'],
-              highlight_weights=['regular'],
-              highlight_styles=['normal'],
-              string_weight='regular',
-              string_style='normal',
-              fig=None,       
-              delim=['<', '>'],
-              va='bottom',
-              ha='left',
-              hpadding=0,
-              linespacing=0.25,
-              **kwargs):
+def fig_text(x, y, s,
+             color=None,
+             highlight_colors=['C1'],
+             highlight_weights=['regular'],
+             highlight_styles=['normal'],
+             fontweight='regular',
+             fontstyle='normal',
+             fig=None,
+             delim=['<', '>'],
+             va='bottom',
+             ha='left',
+             hpadding=0,
+             linespacing=0.25,
+             **kwargs):
     '''
     Takes a string with substrings in delimiters = ['<', '>']
     to be highlighted according to highlight colors:
@@ -210,8 +218,8 @@ def fig_htext(s, x, y,
     highlight_colors: list of highlight colors
     highlight_weights = ['regular']: the fontweight used for highlighted text
     highlight_styles = ['normal']: the fontstyle used for highlighted text
-    string_weight = 'regular': the fontweight used for normal text
-    string_style = 'normal': the fontstyle used for normal text
+    fontweight = 'regular': the fontweight used for normal text
+    fontstyle = 'normal': the fontstyle used for normal text
     delim = ['<', '>']: delimiters to enclose the highlight substrings
     va = 'bottom', textalignment has to be in ['bottom', 'top', 'center']
     ha = 'left', textalignment has to be in ['left', 'right', 'center']
@@ -224,6 +232,10 @@ def fig_htext(s, x, y,
 
     a list of texts
     '''
+
+    if color is None:
+        color = mpl.rcParams['text.color']
+
     def is_empty_string(string):
         return string.strip() == ''
 
@@ -244,7 +256,7 @@ def fig_htext(s, x, y,
     if len(highlight_colors) == 1:
         highlight_colors = np.repeat(highlight_colors, n_highlights)
     else:
-        assert n_highlights == len(highlight_colors), f'You should specify either one highlight color or the same number as text highlights.\nYou input {n_highlights} highlights and {len(highlight_colors)} colors.'    
+        assert n_highlights == len(highlight_colors), f'You should specify either one highlight color or the same number as text highlights.\nYou input {n_highlights} highlights and {len(highlight_colors)} colors.'
 
     if len(highlight_weights) == 1:
         highlight_weights = np.repeat(highlight_weights, n_highlights)
@@ -285,12 +297,12 @@ def fig_htext(s, x, y,
                 if i % 2 == 1:
                     colors.append(highlight_colors[highlight_count])
                     weights.append(highlight_weights[highlight_count])
-                    styles.append(highlight_styles[highlight_count])                
+                    styles.append(highlight_styles[highlight_count])
                     highlight_count += 1
                 else:
                     colors.append(color)
-                    weights.append(string_weight)
-                    styles.append(string_style)
+                    weights.append(fontweight)
+                    styles.append(fontstyle)
 
             texts = []
 
@@ -312,8 +324,8 @@ def fig_htext(s, x, y,
 
             textline_hight = tcboxes[0, -1] - tcboxes[0, 1]
             textline_widths.append((tcboxes[:, 2] - tcboxes[:, 0]).sum())
-            textbox_hight = (tcboxes[0, -1] - tcboxes[0, 1]) * (len(text_rows)
-                             + (len(text_rows) - 1) * linespacing)
+            textbox_hight = ((tcboxes[0, -1] - tcboxes[0, 1]) * (len(text_rows)
+                             + (len(text_rows) - 1) * linespacing))
 
             textline_xs.append(np.hstack([tcboxes[0, 0],
                                           tcboxes[0, 0]


### PR DESCRIPTION
## This is a refactor of the initial package. Some changes made include:

- imports in the init file to allow direct import from highlight_text
  - users can now simply `import highlight_text` and access each module via `highlight_text.<module_name>`
  - or `from highlight_text import <module_name>`

- renamed modules to more clearly reflect their usage:
 - htext is now ax_text
 - fig_htext is now fig_text

- removed some arguments from functions that cause clashes with matplotlib namespace
 - string_weight is now fontweight
 - string_style is now fontstyle

- reordered args to match matplotlib style of x value, y value, string.

- added note to ax_text docstring recommending using `constrained_layout=True` in figure creation instead of `plt.tight_layout()` due to issues with resizing after text creation